### PR TITLE
Add ctype for isprint and fix lib path to that used by make install

### DIFF
--- a/doc/sdk/examples/C/inc/base.h
+++ b/doc/sdk/examples/C/inc/base.h
@@ -21,6 +21,7 @@
 #define basetest_h
 
 #include <stdio.h>
+#include <ctype.h>
 #ifdef WIN32
 //allign at 1 byte
 #pragma pack(push, cryptoki, 1)
@@ -63,7 +64,7 @@
 #ifdef __APPLE__
 #define PKCS11_LIB "/usr/local/lib/libbeidpkcs11.dylib"
 #else
-#define PKCS11_LIB "/usr/lib/x86_64-linux-gnu/libbeidpkcs11.so.0"
+#define PKCS11_LIB "/usr/local/lib/libbeidpkcs11.so.0"
 #endif
 #define TEXT(x) x
 #define _getch() getchar()


### PR DESCRIPTION
I tried to build the samples in Linux (Fedora 23), but ran into 2 (minor) issues. Both of which I fixed in this commit:
* The samples use "isprint", but didn't include ctype.h in which isprintf is defined
* base.h defines the path for beidpkcs11 on Linux as /usr/lib/x86_64-linux-gnu/libbeidpkcs11.so.0, however, when following the standard configure; make; make install steps as instructed by README.md, the library ends up in /usr/local/lib in stead.