### PR TITLE
common/logbase.h: add include for fcntl.h

### DIFF
--- a/cardcomm/pkcs11/src/common/logbase.h
+++ b/cardcomm/pkcs11/src/common/logbase.h
@@ -88,6 +88,7 @@ Example of usage through objects and macro are give at the end of this file
 
 #ifndef WIN32
 #include <sys/file.h>
+#include <fcntl.h>
 #endif
 
 #include <stdarg.h>


### PR DESCRIPTION
Fixes building the package with linux systems that use musl libc like
Void Linux and Alpine Linux.

taken from void-linux/void-packages#294