### PR TITLE
Add libassuan as prerequisite for autoreconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ not for you; in that case, we instead recommend you download it from the
 
 ### Code from git repository:
 
-- Make sure you have libtool 2.2.7c or above, autoconf and automake installed, and in your `$PATH`
+- Make sure you have libtool 2.2.7c or above, autoconf, automake and libassuan are installed, and in your `$PATH`
 - run `autoreconf -i`
 - proceed to the next step
 


### PR DESCRIPTION
Hey,

When following the instructions (on a Debian machine) the only issue I ran against was Libassuan not being installed. Without libassuan, autoreconf will not run so I've added it to the list of prerequisites.

Solved that by running `sudo apt-get install libassuan-dev`.

Thank you for the good readme.md by the way, running into just one issue is pretty great!