### PR TITLE
fix 'unknown type int8_t' errors when compiling for aarch64-musl

### DIFF
--- a/plugins_tools/eid-viewer/test/testlib.c
+++ b/plugins_tools/eid-viewer/test/testlib.c
@@ -23,8 +23,6 @@
 #pragma pack(push, cryptoki, 1)
 #include "pkcs11.h"
 #pragma pack(pop, cryptoki)
-#include <stdio.h>
-#include <stdint.h>
 #include <tchar.h>
 #else
 #include <unix.h>
@@ -38,6 +36,8 @@
 #include <stdarg.h>
 #include <stdbool.h>
 #include <errno.h>
+#include <stdio.h>
+#include <stdint.h>
 
 
 #include "serial_io.h"

--- a/tests/unit/testlib.c
+++ b/tests/unit/testlib.c
@@ -23,8 +23,6 @@
 #pragma pack(push, cryptoki, 1)
 #include "pkcs11.h"
 #pragma pack(pop, cryptoki)
-#include <stdio.h>
-#include <stdint.h>
 #include <tchar.h>
 #else
 #include <unix.h>
@@ -37,6 +35,8 @@
 #include <stdarg.h>
 #include <stdbool.h>
 #include <errno.h>
+#include <stdio.h>
+#include <stdint.h>
 
 #include "testlib.h"
 


### PR DESCRIPTION
(Context: [updating the Void Linux package](https://github.com/void-linux/void-packages/pull/31260) from 4.4.something to 5.0.22, that's why I keep finding these issues now. Should've checked for new dependencies for the first PR, though...)

This is another error I've found, now when trying to cross-compile: on aarch64-musl, the compilation fails in these two files, being unable to resolve `int8_t`, probably due to the wrongly placed header includes.

Note: maybe it's a good idea to add the `eid-mw` Void package to [this list](https://eid.belgium.be/en/faq/which-linux-distributions-are-supported#7403)