### PR TITLE
Include new labels for latest eID cards

### DIFF
--- a/plugins_tools/util/labels.c
+++ b/plugins_tools/util/labels.c
@@ -123,7 +123,7 @@ static struct labelnames *foreignerlabels = NULL;
 			return labels[i].NAME;\
 		}\
 	}\
-	EID_FPRINTF(stderr, TEXT("E: unknown label: %s"), label);\
+	EID_FPRINTF(stderr, TEXT("E: unknown label: %s\n"), label);\
 	return DEFAULT; \
 }
 

--- a/plugins_tools/util/labels.c
+++ b/plugins_tools/util/labels.c
@@ -100,6 +100,9 @@ static struct {
 	{ TEXT("brexit_mention_1"),		CK_TRUE, CK_FALSE, CK_TRUE, TEXT("4.2") },
 	{ TEXT("brexit_mention_2"),		CK_TRUE, CK_FALSE, CK_TRUE, TEXT("4.2") },
 	{ TEXT("tokeninfo_graph_perso_version"),	CK_FALSE, CK_TRUE, CK_TRUE, TEXT("4.4") },
+	{ TEXT("perso_versions"),	CK_FALSE, CK_TRUE, CK_TRUE, NULL },
+	{ TEXT("tokeninfo_elec_perso_version"),	CK_FALSE, CK_TRUE, CK_TRUE, NULL },
+	{ TEXT("tokeninfo_elec_perso_int_version"),	CK_FALSE, CK_TRUE, CK_TRUE, NULL },
 //	{ TEXT("cardA_mention_1"),		CK_TRUE, CK_FALSE, CK_TRUE, TEXT("4.4") }, //extra mentions possible on type A cards
 //	{ TEXT("cardA_mention_2"),		CK_TRUE, CK_FALSE, CK_TRUE, TEXT("4.4") },
 	{ NULL,					0, 0, 0, NULL },


### PR DESCRIPTION
Related to #159, include new labels.
I don't know which minimum version is required for theses fields.

From documentation:
| CKA_CLASS | CKA_LABEL | |
|---|---|---|
| `CKO_DATA` | `tokeninfo_graph_perso_version` | the graphical personalisation version |
| `CKO_DATA` | `tokeninfo_elec_perso_version` | the electrical personalisation version 
| `CKO_DATA` | `tokeninfo_elec_perso_int_version` | the electrical personalisation interface version |
| `CKO_DATA` | `perso_versions` | The 4 personalisation bytes as found in the tokeninfo file on the |


By the way, this add a new line on unknown label error message to improve readability.