### PR TITLE
sign_state.c:74:23: error: incompatible pointer to integer conversion…

### DIFF
--- a/tests/unit/sign_state.c
+++ b/tests/unit/sign_state.c
@@ -71,7 +71,7 @@ TEST_FUNC(sign_state) {
 		printf("Robot not present, can't do this test...\n");
 		return TEST_RV_SKIP;
 	}
-	check_rv_long(C_Sign(NULL, data, sizeof(data), NULL, &sig_len), m_p11_noinit);
+	check_rv_long(C_Sign(NULL_PTR, data, sizeof(data), NULL, &sig_len), m_p11_noinit);
 
 	check_rv(C_Initialize(NULL_PTR));
 


### PR DESCRIPTION
… passing void to parameter of type CK_SESSION_HANDLE (aka unsigned long) [-Wint-conversion]

clang version 17.0.6
Target: x86_64-pc-linux-gnu

/bin/sh ../../libtool  --tag=CC   --mode=link clang -I../../doc/sdk/include/v240 -I../../plugins_tools/util   -O2 -march=x86-64 -pipe -pipe -frecord-gcc-switches -fno-diagnostics-color -fmessage-length=0  -lpcsclite -Wl,-O1 -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0 -Wl,--defsym=__gentoo_check_ldflags__=0 -fuse-ld=lld -o sessioninfo sessioninfo.o libtestlib.la ../../cardcomm/pkcs11/src/libbeidpkcs11.la 
sign_state.c:74:23: error: incompatible pointer to integer conversion passing 'void *' to parameter of type 'CK_SESSION_HANDLE' (aka 'unsigned long') [-Wint-conversion]
   74 |         check_rv_long(C_Sign(NULL, data, sizeof(data), NULL, &sig_len), m_p11_noinit);
      |                              ^~~~
/usr/lib/llvm/17/bin/../../../../lib/clang/17/include/stddef.h:89:16: note: expanded from macro 'NULL'
   89 | #  define NULL ((void*)0)
      |                ^~~~~~~~~~
./testlib.h:112:94: note: expanded from macro 'check_rv_long'
  112 | #define check_rv_long(call, mods) { int c = sizeof(mods) / sizeof(ckrv_mod); check_rv_action(call, c, mods); }
      |                                                                                              ^~~~
./testlib.h:95:13: note: expanded from macro 'check_rv_action'
   95 |         CK_RV rv = call; \
      |                    ^~~~
../../doc/sdk/include/v240/pkcs11f.h:533:21: note: passing argument to parameter 'hSession' here
  533 |         (CK_SESSION_HANDLE hSession,    /* the session's handle */
      |                            ^
