### PR TITLE
pkg-config files with mismatched Version

### DIFF
--- a/cardcomm/pkcs11/src/libbeidpkcs11.pc.in
+++ b/cardcomm/pkcs11/src/libbeidpkcs11.pc.in
@@ -5,6 +5,6 @@ includedir=@includedir@/beid
 
 Name: beidpkcs11
 Description: Beid PKCS#11 interface
-Version: @PACKAGE_VERSION@
+Version: @MAINVERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lbeidpkcs11


### PR DESCRIPTION
Quality Assurance of Gentoo says :
* QA Notice: pkg-config files with mismatched Version found!
* At least /usr/lib/pkgconfig/libbeidpkcs11.pc's Version field does not match 5.1.4
* Please check all .pc files installed by this package.