### PR TITLE
use printf in Makefile

### DIFF
--- a/plugins_tools/eid-viewer/Makefile.am
+++ b/plugins_tools/eid-viewer/Makefile.am
@@ -142,13 +142,13 @@ AM_CXXFLAGS = $(AM_CFLAGS) -std=c++98
 SUBDIRS = . gtk/po test uml
 
 resources/%.c: resources/%.png
-	echo -e "#include <gdk-pixbuf/gdk-pixdata.h>\n#if __GNUC__ >= 4\n#pragma GCC diagnostic push\n#pragma GCC diagnostic ignored \"-Wpointer-sign\"\n#endif\n" > $@
+	printf '%s\n' '#include <gdk-pixbuf/gdk-pixdata.h>' '#if __GNUC__ >= 4' '#pragma GCC diagnostic push' '#pragma GCC diagnostic ignored "-Wpointer-sign"' '#endif' > $@
 	gdk-pixbuf-csource --struct --extern --name `basename $^ .png` $^ >> $@
-	echo -e "#pragma GCC diagnostic pop\n" >> $@
+	printf '%s\n' '#pragma GCC diagnostic pop' >> $@
 resources/%.c: resources/%.jpg
-	echo -e "#include <gdk-pixbuf/gdk-pixdata.h>\n#if __GNUC__ >= 4\n#pragma GCC diagnostic push\n#pragma GCC diagnostic ignored \"-Wpointer-sign\"\n#endif\n" > $@
+	printf '%s\n' '#include <gdk-pixbuf/gdk-pixdata.h>' '#if __GNUC__ >= 4' '#pragma GCC diagnostic push' '#pragma GCC diagnostic ignored "-Wpointer-sign"' '#endif' > $@
 	gdk-pixbuf-csource --struct --extern --name `basename $^ .jpg` $^ >> $@
-	echo -e "#pragma GCC diagnostic pop\n" >> $@
+	printf '%s\n' '#pragma GCC diagnostic pop' >> $@
 
 BUILT_SOURCES = gtk/viewer_glade.h \
 		resources/coat_of_arms_nl.c \


### PR DESCRIPTION
echo -e is not defined by POSIX and varies by shell. Use printf instead for far more portable behaviour.
See also :
https://unix.stackexchange.com/questions/65803/why-is-printf-better-than-echo
https://bugs.gentoo.org/751472