### PR TITLE
compile failed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS = -I scripts/m4
 EXTRA_DIST = scripts/build-aux/config.rpath scripts/build-aux/genver.sh .version debian rpm doc
 
-SUBDIRS=cardcomm/pkcs11/src doc/sdk/include/v240 plugins_tools/util tests/unit plugins_tools/xpi plugins_tools/chrome_pkcs11 tests/fuzz
+SUBDIRS=cardcomm/pkcs11/src doc/sdk/include/v240 plugins_tools/util tests/unit plugins_tools/chrome_pkcs11 tests/fuzz
 
 if GTK
 SUBDIRS += plugins_tools/aboutmw/gtk plugins_tools/eid-viewer

--- a/configure.ac
+++ b/configure.ac
@@ -275,6 +275,5 @@ AC_CONFIG_FILES([Makefile
 		 plugins_tools/eid-viewer/gtk/eid-viewer.desktop.sh
 		 plugins_tools/eid-viewer/uml/Makefile
 		 rpm/eid-mw.spec])
-AC_CONFIG_SUBDIRS([plugins_tools/xpi])
 
 AC_OUTPUT


### PR DESCRIPTION
(...)
configure: WARNING: no configuration information is in plugins_tools/xpi
(...)
Making all in plugins_tools/xpi
make[2]: Entering directory '/var/tmp/portage/app-crypt/eid-mw-9999/work/eid-mw-9999/plugins_tools/xpi' make[2]: *** No rule to make target 'all'.  Stop.
make[2]: Leaving directory '/var/tmp/portage/app-crypt/eid-mw-9999/work/eid-mw-9999/plugins_tools/xpi' make[1]: *** [Makefile:490: all-recursive] Error 1 make[1]: Leaving directory '/var/tmp/portage/app-crypt/eid-mw-9999/work/eid-mw-9999' make: *** [Makefile:418: all] Error 2
(...)

NB: ./configure --without-xpipackage does nothing.