### PR TITLE
Change the "Validate Now" button

### DIFF
--- a/plugins_tools/eid-viewer/OSX/eID Viewer/eID Viewer/Base.lproj/MainMenu.xib
+++ b/plugins_tools/eid-viewer/OSX/eID Viewer/eID Viewer/Base.lproj/MainMenu.xib
@@ -1284,7 +1284,7 @@
                                         </splitView>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0io-gu-IzB">
                                             <rect key="frame" x="477" y="18" width="94" height="23"/>
-                                            <buttonCell key="cell" type="roundTextured" title="Validate now" bezelStyle="texturedRounded" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="fPW-Dr-YAR">
+                                            <buttonCell key="cell" type="push" title="Validate now" bezelStyle="rounded" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="fPW-Dr-YAR">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>


### PR DESCRIPTION
Fixes the "Validate Now" button on the "Certificates" tab.

BEFORE: The button looked disabled

<img width="984" alt="Screenshot 2024-05-03 at 21 01 01" src="https://github.com/Fedict/eid-mw/assets/733352/aa46bce1-186b-42f8-9ac0-ac916c7bfe53">

AFTER: the button looks clickable

<img width="984" alt="Screenshot 2024-05-03 at 20 55 09" src="https://github.com/Fedict/eid-mw/assets/733352/49ede3c6-b870-455e-81ba-532d6136267f">

