### PR TITLE
move SCARD_IO_REQUESTs to local scope, and store protocol in member v…

### DIFF
--- a/cardcomm/pkcs11/src/cardlayer/pcsc.h
+++ b/cardcomm/pkcs11/src/cardlayer/pcsc.h
@@ -162,6 +162,7 @@ private:
 		int m_iTimeoutCount;
 
 		unsigned long m_ulCardTxDelay;	//delay before each transmission to a smartcard; in millie-seconds, default 1
+		unsigned long m_ulProtocol;
 
 	};
 


### PR DESCRIPTION
In Citrix VDI , the e-ID reader crashes with the 2nd read because the dwProtocol parameter of the SCARD_IO_REQUESTs is set to 0.
Problem fixed by setting the structs to local scope and storing the protocol as a member variable