### PR TITLE
Make genver.sh script more robust

### DIFF
--- a/scripts/build-aux/genver.sh
+++ b/scripts/build-aux/genver.sh
@@ -1,22 +1,38 @@
 #!/bin/sh
 
-GITDESC=$(git describe --match="v5*" --all --dirty | sed -e 's,^tags/,,g;s/-/./g')
-VERCLEAN=$(echo $GITDESC|sed -Ee 's/^.*v([0-9]+\.[0-9]+(\.[0-9]+|bp|\.pre[0-9]*)).*$/\1/')
-FORCE_VERSION=${FORCE_VERSION:-0}
-
-GITDESC="$VERCLEAN-$GITDESC"
-
-if [ "$GITDESC" = "-" ]; then
+get_from_dotfile() {
 	if [ -f ".version" ]; then
-		GITDESC=$(cat .version)
+		cat .version
 	else
 		if [ $FORCE_VERSION -gt 1 ]; then
+			>&2 echo "ERROR: Cannot detect version: not a git repository, and no .version file is provided."
 			sleep 10
 			exit 1
+		else
+			echo "0.0.unknown"
+			>&2 echo "WARNING: could not detect package version. Defaulting to 0.0.unknown!"
 		fi
-		GITDESC="0.unknown"
+	fi
+}
+
+if ! command -v git 2>&1 >/dev/null; then
+	# no git binary available -> rely on .version file, or bail out
+	GITDESC="$(get_from_dotfile)"
+else
+	GITDESC="$(git describe --match="v5*" --all --dirty | sed -e 's,^tags/,,g;s/-/./g')"
+	if [ $? != 0 ]; then
+		GITDESC="$(get_from_dotfile)"
+	else
+		VERCLEAN="$(echo "$GITDESC"|sed -Ee 's/^.*v([0-9]+\.[0-9]+(\.[0-9]+|bp|\.pre[0-9]*)).*$/\1/')"
+		FORCE_VERSION="${FORCE_VERSION:-0}"
+
+		GITDESC="$VERCLEAN-$GITDESC"
+
+		if [ "$GITDESC" = "-" ]; then
+			GITDESC="$(get_from_dotfile)"
+		fi
 	fi
 fi
 
-echo $GITDESC > .version
-echo $GITDESC
+echo "$GITDESC" > .version
+echo "$GITDESC"


### PR DESCRIPTION
This pull request came from a fun sequence of events which took a bit to track down:

1. The `eid-mw` Void Linux package is built without `git` available, `$GITDESC` ends up being `0.unknown` (and the script doesn't warn about this)
2. `PACKAGE_VERSION` is thus also `0.unknown`
3. `check_update()` in `gtk/main.c` ([link](https://github.com/Fedict/eid-mw/blob/e054be86915733d7f79d918d5610b82c89b23772/plugins_tools/eid-viewer/gtk/main.c#L131)) tries to split `PACKAGE_VERSION` into _three_ dot-separated components. The last entry is thus `NULL`.
4. The function then attempts to call `strlen()` on this last entry, which segfaults.

Here's an attempt at fixing this, by adding more safety checks in the script, emitting warning and error messages when needed, and also defaulting to `0.0.unknown` instead (so the parsing code doesn't fail). I don't know if making the code in `gtk/main.c` more robust is desirable as well? Handling `PACKAGE_VERSION` as if it's an "untrusted input" would feel sort of silly.