### PR TITLE
Fix Issue #236 keypad bug

### DIFF
--- a/cardcomm/pkcs11/src/dialogs/dialogswin32/dlgwndaskpin.cpp
+++ b/cardcomm/pkcs11/src/dialogs/dialogswin32/dlgwndaskpin.cpp
@@ -46,7 +46,7 @@ dlgWndAskPIN::dlgWndAskPIN( DlgPinInfo pinInfo, DlgPinUsage PinPusage, std::wstr
 	GetMonitorInfo(h_monitor, &mInfo);
 	int pixels_per_inch = GetDeviceCaps(CreateDCW(mInfo.szDevice, NULL, NULL, NULL), LOGPIXELSY);
 	int scalingValue = pixels_per_inch / points_per_inch;
-	int pixels_height = (20 * scalingValue);
+	int pixels_height = (24 * scalingValue); // was 20
 
 	m_UseKeypad = UseKeypad;
 
@@ -85,15 +85,15 @@ dlgWndAskPIN::dlgWndAskPIN( DlgPinInfo pinInfo, DlgPinUsage PinPusage, std::wstr
 		//OK Button
 		HWND hOkButton = CreateWindow(
 			L"BUTTON", GETSTRING_DLG(Ok), WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_DEFPUSHBUTTON, 
-			clientRect.right - 175 * scalingValue, clientRect.bottom - (36 * scalingValue), 
-			72 * scalingValue, 24 * scalingValue, m_hWnd, (HMENU)IDB_OK, m_hInstance, NULL );
+			clientRect.right - 220 * scalingValue, clientRect.bottom - (44 * scalingValue), 
+			100 * scalingValue, 36 * scalingValue, m_hWnd, (HMENU)IDB_OK, m_hInstance, NULL );
 		EnableWindow( hOkButton, false );
 
 		//Cancel Button
 		HWND hCancelButton = CreateWindow(
 			L"BUTTON", GETSTRING_DLG(Cancel), WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 
-			clientRect.right - 95 * scalingValue, clientRect.bottom - 36 * scalingValue, 
-			85 * scalingValue, 24 * scalingValue, m_hWnd, (HMENU)IDB_CANCEL, m_hInstance, NULL );
+			clientRect.right - 110 * scalingValue, clientRect.bottom - 44 * scalingValue, 
+			100 * scalingValue, 36 * scalingValue, m_hWnd, (HMENU)IDB_CANCEL, m_hInstance, NULL );
 
 		m_KeypadHeight=0;
 
@@ -101,13 +101,13 @@ dlgWndAskPIN::dlgWndAskPIN( DlgPinInfo pinInfo, DlgPinUsage PinPusage, std::wstr
 		if( m_UseKeypad )
 		{
 			int top = 60 * scalingValue;
-			int hMargin = 12 * scalingValue;
-			int vMargin = 12 * scalingValue;
-			int btnwidth = 48 * scalingValue;
-			int btnheight = 48 * scalingValue;
-			int totwidth = btnwidth*3 + 2*hMargin;
-			int totheight = btnheight*4 +3*vMargin;
-			int left = (clientRect.right - clientRect.left - totwidth)/2;
+			int hMargin = 16 * scalingValue;
+			int vMargin = 16 * scalingValue;
+			int btnwidth  = 64 * scalingValue;  // was 48
+			int btnheight = 64 * scalingValue;  // was 48
+			int totwidth  = btnwidth * 3 + 2 * hMargin;
+			int totheight = btnheight * 4 + 3 * vMargin;
+			int left = (clientRect.right - clientRect.left - totwidth) / 2;
 			m_KeypadHeight = top + totheight + 8;
 
 			for( int i = 0; i < 4; i++ )
@@ -123,20 +123,20 @@ dlgWndAskPIN::dlgWndAskPIN( DlgPinInfo pinInfo, DlgPinUsage PinPusage, std::wstr
 				}
 			}
 
-			ImageKP_BTN[0] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_0) );
-			ImageKP_BTN[1] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_1) );
-			ImageKP_BTN[2] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_2) );
-			ImageKP_BTN[3] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_3) );
-			ImageKP_BTN[4] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_4) );
-			ImageKP_BTN[5] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_5) );
-			ImageKP_BTN[6] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_6) );
-			ImageKP_BTN[7] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_7) );
-			ImageKP_BTN[8] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_8) );
-			ImageKP_BTN[9] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_9) );
-			ImageKP_BTN[10] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_CE) );
-			ImageKP_BTN[11] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_BTN) );
+			ImageKP_BTN[0]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_0),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[1]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_1),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[2]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_2),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[3]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_3),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[4]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_4),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[5]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_5),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[6]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_6),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[7]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_7),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[8]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_8),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[9]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_9),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[10] = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_CE),  IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[11] = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_BTN), IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
 
-			CreateBitapMask( ImageKP_BTN[11], ImageKP_BTN_Mask );
+			CreateBitapMask(ImageKP_BTN[11], ImageKP_BTN_Mask );
 			//MWLOG(LEV_DEBUG, MOD_DLG, L" dlgWndAskPIN : Virtual pinpad - LoadBitmap");
 		}
 
@@ -145,22 +145,22 @@ dlgWndAskPIN::dlgWndAskPIN( DlgPinInfo pinInfo, DlgPinUsage PinPusage, std::wstr
 			dwStyle |= ES_NUMBER;
 
 		LONG pinTop=0;
-		LONG pinLeft=clientRect.right/2 - 100 * scalingValue + 40;
+		LONG pinLeft=clientRect.right/2 - 120 * scalingValue + 40;
 
 		if( m_UseKeypad )
 			pinTop = clientRect.top + 20 * scalingValue;
 		else
-			pinTop = clientRect.bottom - 80 * scalingValue;
+			pinTop = clientRect.bottom - 100 * scalingValue;
 
 		HWND hTextEdit = CreateWindowEx( WS_EX_CLIENTEDGE,
 			L"EDIT", L"", dwStyle, 
-			pinLeft, pinTop, 160 * scalingValue, 26 * scalingValue,
+			pinLeft, pinTop, 220 * scalingValue, 34 * scalingValue, // wider and taller
 			m_hWnd, (HMENU)IDC_EDIT, m_hInstance, NULL );
 		SendMessage( hTextEdit, EM_LIMITTEXT, m_ulPinMaxLen, 0 );
 
 		HWND hStaticText = CreateWindow( 
 			L"STATIC", szPIN, WS_CHILD | WS_VISIBLE | SS_RIGHT, 
-			pinLeft-100 * scalingValue, pinTop +4 , 96 * scalingValue, 22 * scalingValue,
+			pinLeft-110 * scalingValue, pinTop + 4, 106 * scalingValue, 26 * scalingValue, // a bit taller label
 			m_hWnd, (HMENU)IDC_STATIC, m_hInstance, NULL );
 
 		SendMessage( hStaticText, WM_SETFONT, (WPARAM)TextFont, 0 );
@@ -180,7 +180,16 @@ dlgWndAskPIN::dlgWndAskPIN( DlgPinInfo pinInfo, DlgPinUsage PinPusage, std::wstr
 
 dlgWndAskPIN::~dlgWndAskPIN()
 {
-	KillWindow( );
+	KillWindow();
+
+	for (int i = 0; i < 12; ++i)
+	{
+		if (ImageKP_BTN[i]) { DeleteObject(ImageKP_BTN[i]); ImageKP_BTN[i] = NULL; }
+	}
+	if (ImageKP_BTN_Mask) { DeleteObject(ImageKP_BTN_Mask); ImageKP_BTN_Mask = NULL; }
+	if (ImagePIN) { DeleteObject(ImagePIN); ImagePIN = NULL; }
+	if (ImagePIN_Mask) { DeleteObject(ImagePIN_Mask); ImagePIN_Mask = NULL; }
+	if (TextFont) { DeleteObject(TextFont); TextFont = NULL; }
 }
 
 void dlgWndAskPIN::GetPinResult()
@@ -264,51 +273,73 @@ LRESULT dlgWndAskPIN::ProcecEvent
 			LPDRAWITEMSTRUCT lpDrawItem = (LPDRAWITEMSTRUCT)lParam;
 			if( lpDrawItem->CtlType & ODT_BUTTON )
 			{
-				//MWLOG(LEV_DEBUG, MOD_DLG, L" dlgWndAskPIN : Virtual pinpad - WM_DRAWITEM lParam=%x, wParam=%ld",lParam,wParam);
-				//MWLOG(LEV_DEBUG, MOD_DLG, L" dlgWndAskPIN : Virtual pinpad - Entering WM_DRAWITEM lpDrawItem->hDC=%ld",lpDrawItem->hDC);
+				HBRUSH hbrFace = GetSysColorBrush(COLOR_3DFACE);
+				FillRect(lpDrawItem->hDC, &lpDrawItem->rcItem, hbrFace);
 
-				FillRect( lpDrawItem->hDC, &lpDrawItem->rcItem, CreateSolidBrush( GetSysColor( COLOR_3DFACE ) ) );
-				//MWLOG(LEV_DEBUG, MOD_DLG, L" dlgWndAskPIN : Virtual pinpad - WM_DRAWITEM top=%ld, bottom=%ld, left=%ld, right=%ld",
-					//lpDrawItem->rcItem.top,lpDrawItem->rcItem.bottom,lpDrawItem->rcItem.left,lpDrawItem->rcItem.right);
+				// Base face image (optional)
+				if (ImageKP_BTN[11] && ImageKP_BTN_Mask)
+				{
+					HDC hdcMem = CreateCompatibleDC(lpDrawItem->hDC);
+					HGDIOBJ hOld = SelectObject(hdcMem, ImageKP_BTN[11]);
+					MaskBlt(lpDrawItem->hDC,
+						(lpDrawItem->rcItem.right  - KP_BTN_SIZE) / 2,
+						(lpDrawItem->rcItem.bottom - KP_BTN_SIZE) / 2,
+						KP_BTN_SIZE, KP_BTN_SIZE,
+						hdcMem, 0, 0,
+						ImageKP_BTN_Mask, 0, 0, MAKEROP4(SRCCOPY, 0x00AA0029));
+					SelectObject(hdcMem, hOld);
+					DeleteDC(hdcMem);
+				}
+				else
+				{
+					RECT r = lpDrawItem->rcItem;
+					DrawEdge(lpDrawItem->hDC, &r, EDGE_RAISED, BF_RECT);
+				}
 
-				HDC hdcMem = CreateCompatibleDC( lpDrawItem->hDC );
-				SelectObject( hdcMem , ImageKP_BTN[11] );
-				MaskBlt( lpDrawItem->hDC, (lpDrawItem->rcItem.right - KP_BTN_SIZE) / 2, (lpDrawItem->rcItem.bottom - KP_BTN_SIZE) / 2,
-					KP_BTN_SIZE, KP_BTN_SIZE, hdcMem, 0, 0,
-					ImageKP_BTN_Mask, 0, 0, MAKEROP4( SRCCOPY, 0x00AA0029 ) );
-
+				// Determine label index and text
 				unsigned int iNum = 0;
-				if( lpDrawItem->CtlID == IDB_KeypadEnd )
+				wchar_t label[3] = L"";
+				if (lpDrawItem->CtlID == IDB_KeypadEnd)         { iNum = 10; wcscpy_s(label, L"CE"); }
+				else if (lpDrawItem->CtlID == IDB_KeypadEnd - 1) { iNum = 0;  wcscpy_s(label, L"0");  }
+				else if (lpDrawItem->CtlID >= IDB_KeypadStart && lpDrawItem->CtlID < IDB_KeypadEnd - 2)
 				{
-					iNum = 10;
+					iNum = (lpDrawItem->CtlID - IDB_KeypadStart) + 1; // 1..9
+					label[0] = L'0' + (wchar_t)iNum; label[1] = L'\0';
 				}
-				else if( lpDrawItem->CtlID >= IDB_KeypadStart && lpDrawItem->CtlID < IDB_KeypadEnd -2 )
-				{
-					iNum = lpDrawItem->CtlID - IDB_KeypadStart +1;
-				}
-				//MWLOG(LEV_DEBUG, MOD_DLG, L" dlgWndAskPIN : Virtual pinpad - WM_DRAWITEM iNum=%ld",iNum);
 
-				SelectObject( hdcMem , ImageKP_BTN[iNum] );
-				BitBlt( lpDrawItem->hDC, (lpDrawItem->rcItem.right - KP_LBL_SIZE) / 2, (lpDrawItem->rcItem.bottom - KP_LBL_SIZE) / 2, 
-						KP_LBL_SIZE, KP_LBL_SIZE, hdcMem, 0, 0, SRCCOPY );
-				DeleteDC(hdcMem);
-
-				if( lpDrawItem->itemState & ODS_SELECTED )
-					DrawEdge( lpDrawItem->hDC, &lpDrawItem->rcItem, EDGE_RAISED, BF_RECT );
-				
-				if( lpDrawItem->itemState & ODS_HOTLIGHT )
-					DrawEdge( lpDrawItem->hDC, &lpDrawItem->rcItem, EDGE_SUNKEN, BF_RECT );
-				
-				if( lpDrawItem->itemState & ODS_FOCUS )
+				// Draw label bitmap if available, else text
+				if (iNum <= 10 && ImageKP_BTN[iNum])
 				{
-					GetClientRect( lpDrawItem->hwndItem, &rect );
-					rect.left += 2;
-					rect.right -= 2;
-					rect.top += 2;
-					rect.bottom -= 2;
-					DrawFocusRect( lpDrawItem->hDC, &rect );
+					HDC hdcMem = CreateCompatibleDC(lpDrawItem->hDC);
+					HGDIOBJ hOld = SelectObject(hdcMem, ImageKP_BTN[iNum]);
+					BitBlt(lpDrawItem->hDC,
+						(lpDrawItem->rcItem.right  - KP_LBL_SIZE) / 2,
+						(lpDrawItem->rcItem.bottom - KP_LBL_SIZE) / 2,
+						KP_LBL_SIZE, KP_LBL_SIZE, hdcMem, 0, 0, SRCCOPY);
+					SelectObject(hdcMem, hOld);
+					DeleteDC(hdcMem);
 				}
-				//MWLOG(LEV_DEBUG, MOD_DLG, L" dlgWndAskPIN : Virtual pinpad - Leaving WM_DRAWITEM lpDrawItem->hDC=%ld",lpDrawItem->hDC);
+				else
+				{
+					SetBkMode(lpDrawItem->hDC, TRANSPARENT);
+					SetTextColor(lpDrawItem->hDC, GetSysColor(COLOR_BTNTEXT));
+					HFONT hOldFont = (HFONT)SelectObject(lpDrawItem->hDC, TextFont);
+					RECT tr = lpDrawItem->rcItem;
+					tr.left += 2; tr.right -= 2; tr.top += 2; tr.bottom -= 2;
+					DrawText(lpDrawItem->hDC, label, -1, &tr, DT_SINGLELINE | DT_CENTER | DT_VCENTER);
+					SelectObject(lpDrawItem->hDC, hOldFont);
+				}
+
+				if (lpDrawItem->itemState & ODS_SELECTED)
+					DrawEdge(lpDrawItem->hDC, &lpDrawItem->rcItem, EDGE_RAISED, BF_RECT);
+				if (lpDrawItem->itemState & ODS_HOTLIGHT)
+					DrawEdge(lpDrawItem->hDC, &lpDrawItem->rcItem, EDGE_SUNKEN, BF_RECT);
+				if (lpDrawItem->itemState & ODS_FOCUS)
+				{
+					RECT r; GetClientRect(lpDrawItem->hwndItem, &r);
+					r.left += 2; r.right -= 2; r.top += 2; r.bottom -= 2;
+					DrawFocusRect(lpDrawItem->hDC, &r);
+				}
 				return TRUE;
 			}
 			break;
@@ -355,13 +386,13 @@ LRESULT dlgWndAskPIN::ProcecEvent
 			}
 
 			GetClientRect( m_hWnd, &rect );
-			rect.left += IMG_SIZE + 16;
-			rect.top = m_KeypadHeight + 8;
-			rect.right -= 8;
-			rect.bottom = rect.bottom - 40;
+			rect.left   += 8;
+			rect.top     = m_KeypadHeight + 8;
+			rect.right  -= 8;
+			rect.bottom  = rect.bottom - 40;
 			SetBkColor( m_hDC, GetSysColor( COLOR_3DFACE ) );
 			SelectObject( m_hDC, TextFont );
-			DrawText( m_hDC, szHeader, -1, &rect, DT_WORDBREAK );
+			DrawText( m_hDC, szHeader, -1, &rect, DT_WORDBREAK | DT_CENTER);
 
 			EndPaint( m_hWnd, &ps );
 

--- a/cardcomm/pkcs11/src/dialogs/dialogswin32/dlgwndaskpins.cpp
+++ b/cardcomm/pkcs11/src/dialogs/dialogswin32/dlgwndaskpins.cpp
@@ -1,4 +1,4 @@
-/* ****************************************************************************
+﻿/* ****************************************************************************
 
  * eID Middleware Project.
  * Copyright (C) 2008-2010 FedICT.
@@ -90,14 +90,14 @@ dlgWndAskPINs::dlgWndAskPINs( DlgPinInfo pinInfo1, DlgPinInfo pinInfo2, std::wst
 
 		HWND hOkButton = CreateWindow(
 			L"BUTTON", GETSTRING_DLG(Ok), WS_CHILD | WS_VISIBLE | WS_TABSTOP, 
-			clientRect.right - 175 * scalingValue, clientRect.bottom - 36 * scalingValue, 
-			72 * scalingValue, 24 * scalingValue, m_hWnd, (HMENU)IDB_OK, m_hInstance, NULL );
+			clientRect.right - 220 * scalingValue, clientRect.bottom - 44 * scalingValue, 
+			100 * scalingValue, 36 * scalingValue, m_hWnd, (HMENU)IDB_OK, m_hInstance, NULL );
 		EnableWindow( hOkButton, false );
 
 		HWND hCancelButton = CreateWindow(
 			L"BUTTON", GETSTRING_DLG(Cancel), WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_DEFPUSHBUTTON, 
-			clientRect.right - 95 * scalingValue, clientRect.bottom - 36 * scalingValue, 
-			85 * scalingValue, 24 * scalingValue, m_hWnd, (HMENU)IDB_CANCEL, m_hInstance, NULL );
+			clientRect.right - 110 * scalingValue, clientRect.bottom - 44 * scalingValue, 
+			100 * scalingValue, 36 * scalingValue, m_hWnd, (HMENU)IDB_CANCEL, m_hInstance, NULL );
 
 		DWORD dwStyle = WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_BORDER | ES_PASSWORD;
 		if( pinInfo1.ulFlags & PIN_FLAG_DIGITS )
@@ -107,10 +107,10 @@ dlgWndAskPINs::dlgWndAskPINs( DlgPinInfo pinInfo1, DlgPinInfo pinInfo2, std::wst
 		{
 			m_UK_InputField = 0;
 
-			HWND hTextEdit = CreateWindowEx( WS_EX_CLIENTEDGE,
+			HWND hTextEdit = CreateWindowEx(WS_EX_CLIENTEDGE,
 				L"EDIT", L"", dwStyle, 
 				62 * scalingValue, clientRect.top + 20 * scalingValue, 
-				clientRect.right - 94 * scalingValue, 26 * scalingValue,
+				clientRect.right - 94 * scalingValue, 34 * scalingValue, // was 26
 				m_hWnd, (HMENU)IDC_EDIT, m_hInstance, NULL );
 			SendMessage( hTextEdit, EM_LIMITTEXT, m_ulPin1MaxLen, 0 );
 
@@ -128,17 +128,21 @@ dlgWndAskPINs::dlgWndAskPINs( DlgPinInfo pinInfo1, DlgPinInfo pinInfo2, std::wst
 			int vMargin = 12 * scalingValue;
 			int totwidth = right - left;
 			int totheight = bottom - top;
-			int btnwidth = ( totwidth - 2*hMargin ) / 3;
-			int btnheight = ( totheight - 3*vMargin ) /4;
-			if( btnheight < btnwidth )
-			{
+			int btnwidth  = (totwidth  - 2 * hMargin) / 3;
+			int btnheight = (totheight - 3 * vMargin) / 4;
+
+			// Enforce a minimum touch size (≈64px @ 96 DPI)
+			const int minTouch = 56 * scalingValue; // 56–64px works well; 56 keeps more layouts fitting
+			btnwidth  = max(btnwidth,  minTouch);
+			btnheight = max(btnheight, minTouch);
+
+			// Keep them square and re-center margins as needed
+			if (btnheight < btnwidth) {
 				btnwidth = btnheight;
-				hMargin = (totwidth - 3*btnwidth)/2;
-			}
-			else if( btnheight > btnwidth )
-			{
+				hMargin = (totwidth - 3 * btnwidth) / 2;
+			} else if (btnheight > btnwidth) {
 				btnheight = btnwidth;
-				vMargin = (totheight - 3*btnheight)/2;
+				vMargin = (totheight - 3 * btnheight) / 2;
 			}
 			for( int i = 0; i < 4; i++ )
 			{
@@ -153,20 +157,19 @@ dlgWndAskPINs::dlgWndAskPINs( DlgPinInfo pinInfo1, DlgPinInfo pinInfo2, std::wst
 				}
 			}
 
-			ImageKP_BTN[0] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_0) );
-			ImageKP_BTN[1] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_1) );
-			ImageKP_BTN[2] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_2) );
-			ImageKP_BTN[3] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_3) );
-			ImageKP_BTN[4] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_4) );
-			ImageKP_BTN[5] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_5) );
-			ImageKP_BTN[6] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_6) );
-			ImageKP_BTN[7] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_7) );
-			ImageKP_BTN[8] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_8) );
-			ImageKP_BTN[9] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_9) );
-			ImageKP_BTN[10] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_CE) );
-			ImageKP_BTN[11] = LoadBitmap( m_hInstance, MAKEINTRESOURCE(IDB_KP_BTN) );
-			//for( unsigned  int i = 0; i < 12; i++ )
-				CreateBitapMask( ImageKP_BTN[11], ImageKP_BTN_Mask );
+			ImageKP_BTN[0]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_0),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[1]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_1),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[2]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_2),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[3]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_3),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[4]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_4),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[5]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_5),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[6]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_6),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[7]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_7),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[8]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_8),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[9]  = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_9),   IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[10] = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_CE),  IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			ImageKP_BTN[11] = reinterpret_cast<HBITMAP>(LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDB_KP_BTN), IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+			CreateBitapMask(ImageKP_BTN[11], ImageKP_BTN_Mask );
 			
 			SendMessage( hStaticText, WM_SETFONT, (WPARAM)TextFont, 0 );
 		}
@@ -234,6 +237,17 @@ dlgWndAskPINs::dlgWndAskPINs( DlgPinInfo pinInfo1, DlgPinInfo pinInfo2, std::wst
 dlgWndAskPINs::~dlgWndAskPINs()
 {
 	KillWindow( );
+
+	for (int i = 0; i < 12; ++i)
+	{
+		if (ImageKP_BTN[i]) { DeleteObject(ImageKP_BTN[i]); ImageKP_BTN[i] = NULL; }
+	}
+	if (ImageKP_BTN_Mask) { DeleteObject(ImageKP_BTN_Mask); ImageKP_BTN_Mask = NULL; }
+
+	if (ImagePIN) { DeleteObject(ImagePIN); ImagePIN = NULL; }
+	if (ImagePIN_Mask) { DeleteObject(ImagePIN_Mask); ImagePIN_Mask = NULL; }
+
+	if (TextFont) { DeleteObject(TextFont); TextFont = NULL; }
 }
 
 void dlgWndAskPINs::GetPinResult()
@@ -460,41 +474,72 @@ LRESULT dlgWndAskPINs::ProcecEvent
 			LPDRAWITEMSTRUCT lpDrawItem = (LPDRAWITEMSTRUCT)lParam;
 			if( lpDrawItem->CtlType & ODT_BUTTON )
 			{
-				FillRect( lpDrawItem->hDC, &lpDrawItem->rcItem, CreateSolidBrush( GetSysColor( COLOR_3DFACE ) ) );
-				HDC hdcMem = CreateCompatibleDC( lpDrawItem->hDC );
-				SelectObject( hdcMem , ImageKP_BTN[11] );
-				MaskBlt( lpDrawItem->hDC, (lpDrawItem->rcItem.right - KP_BTN_SIZE) / 2, (lpDrawItem->rcItem.bottom - KP_BTN_SIZE) / 2,
-					KP_BTN_SIZE, KP_BTN_SIZE, hdcMem, 0, 0,
-					ImageKP_BTN_Mask, 0, 0, MAKEROP4( SRCCOPY, 0x00AA0029 ) );
+				// Background without leaking a brush
+				HBRUSH hbrFace = GetSysColorBrush(COLOR_3DFACE);
+				FillRect(lpDrawItem->hDC, &lpDrawItem->rcItem, hbrFace);
 
+				// Base face image (optional)
+				if (ImageKP_BTN[11] && ImageKP_BTN_Mask)
+				{
+					HDC hdcMem = CreateCompatibleDC(lpDrawItem->hDC);
+					HGDIOBJ hOld = SelectObject(hdcMem, ImageKP_BTN[11]);
+					MaskBlt(lpDrawItem->hDC,
+						(lpDrawItem->rcItem.right  - KP_BTN_SIZE) / 2,
+						(lpDrawItem->rcItem.bottom - KP_BTN_SIZE) / 2,
+						KP_BTN_SIZE, KP_BTN_SIZE,
+						hdcMem, 0, 0,
+						ImageKP_BTN_Mask, 0, 0, MAKEROP4(SRCCOPY, 0x00AA0029));
+					SelectObject(hdcMem, hOld);
+					DeleteDC(hdcMem);
+				}
+				else
+				{
+					RECT r = lpDrawItem->rcItem;
+					DrawEdge(lpDrawItem->hDC, &r, EDGE_RAISED, BF_RECT);
+				}
+
+				// Determine label and text
 				unsigned int iNum = 0;
-				if( lpDrawItem->CtlID == IDB_KeypadEnd )
+				wchar_t label[3] = L"";
+				if (lpDrawItem->CtlID == IDB_KeypadEnd)         { iNum = 10; wcscpy_s(label, L"CE"); }
+				else if (lpDrawItem->CtlID == IDB_KeypadEnd - 1) { iNum = 0;  wcscpy_s(label, L"0");  }
+				else if (lpDrawItem->CtlID >= IDB_KeypadStart && lpDrawItem->CtlID < IDB_KeypadEnd - 2)
 				{
-					iNum = 10;
+					iNum = (lpDrawItem->CtlID - IDB_KeypadStart) + 1; // 1..9
+					label[0] = L'0' + (wchar_t)iNum; label[1] = L'\0';
 				}
-				else if( lpDrawItem->CtlID >= IDB_KeypadStart && lpDrawItem->CtlID < IDB_KeypadEnd -2 )
-				{
-					iNum = lpDrawItem->CtlID - IDB_KeypadStart +1;
-				}
-				SelectObject( hdcMem , ImageKP_BTN[iNum] );
-				BitBlt( lpDrawItem->hDC, (lpDrawItem->rcItem.right - KP_LBL_SIZE) / 2, (lpDrawItem->rcItem.bottom - KP_LBL_SIZE) / 2, 
-						KP_LBL_SIZE, KP_LBL_SIZE, hdcMem, 0, 0, SRCCOPY );
-				DeleteDC(hdcMem);
 
-				if( lpDrawItem->itemState & ODS_SELECTED )
-					DrawEdge( lpDrawItem->hDC, &lpDrawItem->rcItem, EDGE_RAISED, BF_RECT );
-				
-				if( lpDrawItem->itemState & ODS_HOTLIGHT )
-					DrawEdge( lpDrawItem->hDC, &lpDrawItem->rcItem, EDGE_SUNKEN, BF_RECT );
-				
-				if( lpDrawItem->itemState & ODS_FOCUS )
+				if (iNum <= 10 && ImageKP_BTN[iNum])
 				{
-					GetClientRect( lpDrawItem->hwndItem, &rect );
-					rect.left += 2;
-					rect.right -= 2;
-					rect.top += 2;
-					rect.bottom -= 2;
-					DrawFocusRect( lpDrawItem->hDC, &rect );
+					HDC hdcMem = CreateCompatibleDC(lpDrawItem->hDC);
+					HGDIOBJ hOld = SelectObject(hdcMem, ImageKP_BTN[iNum]);
+					BitBlt(lpDrawItem->hDC,
+						(lpDrawItem->rcItem.right  - KP_LBL_SIZE) / 2,
+						(lpDrawItem->rcItem.bottom - KP_LBL_SIZE) / 2,
+						KP_LBL_SIZE, KP_LBL_SIZE, hdcMem, 0, 0, SRCCOPY);
+					SelectObject(hdcMem, hOld);
+					DeleteDC(hdcMem);
+				}
+				else
+				{
+					SetBkMode(lpDrawItem->hDC, TRANSPARENT);
+					SetTextColor(lpDrawItem->hDC, GetSysColor(COLOR_BTNTEXT));
+					HFONT hOldFont = (HFONT)SelectObject(lpDrawItem->hDC, TextFont);
+					RECT tr = lpDrawItem->rcItem;
+					tr.left += 2; tr.right -= 2; tr.top += 2; tr.bottom -= 2;
+					DrawText(lpDrawItem->hDC, label, -1, &tr, DT_SINGLELINE | DT_CENTER | DT_VCENTER);
+					SelectObject(lpDrawItem->hDC, hOldFont);
+				}
+
+				if (lpDrawItem->itemState & ODS_SELECTED)
+					DrawEdge(lpDrawItem->hDC, &lpDrawItem->rcItem, EDGE_RAISED, BF_RECT);
+				if (lpDrawItem->itemState & ODS_HOTLIGHT)
+					DrawEdge(lpDrawItem->hDC, &lpDrawItem->rcItem, EDGE_SUNKEN, BF_RECT);
+				if (lpDrawItem->itemState & ODS_FOCUS)
+				{
+					RECT r; GetClientRect(lpDrawItem->hwndItem, &r);
+					r.left += 2; r.right -= 2; r.top += 2; r.bottom -= 2;
+					DrawFocusRect(lpDrawItem->hDC, &r);
 				}
 				return TRUE;
 			}


### PR DESCRIPTION


We provide citizens with kiosks that allow them to print documents.

We have repeatedly noticed that the Windows virtual keyboard (TabTip.exe) does not appear when selecting the PIN field.

While reviewing the source code, I found that it was possible to add a DWORD key to enable the keypad. Unfortunately, the keypad does not display the bitmaps, making the buttons appear invisible: 

<img width="497" height="521" alt="Screenshot 2025-10-15 155233" src="https://github.com/user-attachments/assets/1613cf9d-8130-479a-9fd8-a443ded434b4" />

With the help of ChatGPT, I modified the source code to use standard buttons with simple labels instead:
<img width="478" height="507" alt="Screenshot 2025-10-21 094138" src="https://github.com/user-attachments/assets/b091f375-554a-462c-989a-abf159ad3e4c" />

We believe these modifications could benefit other public administrations encountering the same problem.
