### PR TITLE
chore(ci): bump GitHub Actions used by docs + publiccode validation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ jobs:
   generate-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: update apt cache
       run: sudo apt-get update
     - name: install prereqs
@@ -20,7 +20,7 @@ jobs:
       working-directory: doc/sdk/eidviewer
       run: doxygen Doxyfile
     - name: publish
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./doc/sdk/eidviewer/html

--- a/.github/workflows/publiccode-yml-validation.yml
+++ b/.github/workflows/publiccode-yml-validation.yml
@@ -6,7 +6,7 @@ jobs:
   publiccode_yml_validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: italia/publiccode-parser-action@v1
         with:
           publiccode: 'publiccode.yml'


### PR DESCRIPTION
Update actions/checkout to v6 and peaceiris/actions-gh-pages to v4. Keeping workflow actions up to date helps us stay secure, compatible with GitHub runner changes, and reduces CI breakage from deprecated versions.